### PR TITLE
mikutter 3.9.1 以降では receive_user_idnames を使用する

### DIFF
--- a/twitter_home_tracker.rb
+++ b/twitter_home_tracker.rb
@@ -56,7 +56,12 @@ Plugin.create(:twitter_home_tracker) do
     # リプライは自分かフォロイーに向いているものに限定して転送する
     # (昔ながらのin_reply_toを持たない手打ちのリプライも対象)
     # in_reply_toが付与されているが自己宛で@から始まっていないスレッドツイートや、メンションの場合は全て転送する
-    mentions = msg.receive_user_screen_names
+    if defined? msg.receive_user_idnames
+      mentions = msg.receive_user_idnames
+    else
+      mentions = msg.receive_user_screen_names
+    end
+
     if !mentions.empty? && msg.body.start_with?("@")
       followings.include?(msg.user) && mentions.any? { |idname|
         service.idname == idname || followings.any? { |u| u.idname == idname }


### PR DESCRIPTION
receive_user_screen_names は非推奨となり、代わりに receive_user_idnames が実装された。  
今後はこちらを使用する必要がある。

https://dev.mikutter.hachune.net/projects/mikutter/repository/main/revisions/730783f482fd7dddd2e43715b8fc42b500cf9da2